### PR TITLE
feat: add --dry-run (-n) flag to show what would happen

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2023 Aspen Dev Box Team
-
 */
 package cmd
 
@@ -45,5 +44,5 @@ func Execute() {
 }
 
 func init() {
-	// Add global flags here if needed
+	rootCmd.PersistentFlags().BoolP("dry-run", "n", false, "Show what would be done without executing")
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"adb/pkg/config"
+
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/spf13/cobra"
 )
@@ -79,6 +81,12 @@ You can also select which ILS to use (koha or evergreen).`,
 
 			if pullUpdated {
 				pullImages(commandArgs)
+			}
+
+			dryRun, _ := cmd.Flags().GetBool("dry-run")
+			if dryRun {
+				fmt.Printf("dry-run: would execute: docker %s\n", strings.Join(commandArgs, " "))
+				return
 			}
 
 			command := exec.Command("docker", commandArgs...)


### PR DESCRIPTION
I was quite hesitant to run a binary just checked into this directory until I knew where it came from.  Then I was hesitant to run the adb binary because I did not know exactly what it was doing.  By using `up --dry-run` or `up -n` it will now print the docker command line without executing it.