### PR TITLE
feat: support local.yml override

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -71,6 +71,12 @@ You can also select which ILS to use (koha or evergreen).`,
 				os.Exit(1)
 			}
 
+			// Add local.yml file, if it exists
+			localComposeFile := filepath.Join(aspenDocker, "local.yml")
+			if _, err := os.Stat(localComposeFile); err == nil {
+				commandArgs = append(commandArgs, "-f", localComposeFile)
+			}
+
 			commandArgs = append(commandArgs, "up")
 
 			if detached {


### PR DESCRIPTION
I have made a significantly smaller eg-docker container, and I want to use it.  The way I did this manually was to specify local.yml last, and to override the image inside that local.yml.  This PR automates adding it last if it exists.